### PR TITLE
添加设置检测与获取copymanga的url列表

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 backup.csv
 backup.txt
 settings.json
+settings_old.json
 *.jpg
 *.webp
 

--- a/README-EN.md
+++ b/README-EN.md
@@ -51,9 +51,15 @@ If you are an Android user, then you can use the [tachiyomi](https://github.com/
 
 If you need to stitch images **right to left** and in groups of two, you can try using `Image_ stitching.exe` in [this version]() to achieve this (only simple functions are provided, no optimization is made)
 
+If you find that you can't get/download, please try a few more times, if not please delete the fields marked in the figure below, trigger the setting deficiency to backup the old settings and reinitialize ( **please don't delete the double quotes!** )
+
+![image.png](https://s2.loli.net/2022/07/05/iXJTlowxnO2GCfc.png)
+
 ## Updates 🔬
 
 ### Major updates 📈
+
+2022/7/5: Fix the problem that the comic group only shows "default" and "other", add the list of URLs to get copymanga from GitHub, add an error when setting is missing and backup the old settings file and re-enter Initialization
 
 2022/6/8: Implemented support 'other' group with the help of [@zaazwm](https://github.com/zaazwm) ，Fix collection export problem and export csv
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,15 @@ QQ `3594254539`（不常工作时间上线）
 
 如果您需要**从右到左**的拼接图片，并且两张为一组的话，您可以尝试使用[这个版本](https://github.com/misaka10843/copymanga-downloader/releases/tag/v2.2)中的 `Image_stitching.exe`来实现(只提供简单功能，并未做出优化)
 
+如果发现无法获取/下载的时候，请多试几次，如果不行的话请删除下图中标明的字段，触发设置缺损备份旧设置并重新初始化(**请不要删除双引号！**)
+
+![image.png](https://s2.loli.net/2022/07/05/iXJTlowxnO2GCfc.png)
+
 ## 更新 🔬
 
 ### 重大更新 📈
+
+2022/7/5: 修复漫画分组只显示“默认”与“其他”的问题，添加从GitHub中获取copymanga的url列表，添加设置缺损后报错并备份老设置文件后重新进入初始化
 
 2022/6/8: 在[@zaazwm](https://github.com/zaazwm)帮助下实现了“其他”内容的下载，修复收藏导出问题与导出csv
 


### PR DESCRIPTION
如果设置中缺失下载路径/请求地址，将报错并备份原来的settings.json后重新进入初始化
并且添加获取copymanga的url列表，如果无法访问可以删除settings.json中的api_url字段后触发初始化程序来获取最新的url列表